### PR TITLE
Randomize Cards, Button/CheckboxButton Components, and react-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "motion": "^12.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.4.0",
     "tailwindcss": "^4.0.6"
   },
   "devDependencies": {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,7 +7,13 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 const Button= ({children, ...props}: ButtonProps) => {
 
     return (
-        <button {...props}>{children}</button>
+        <button 
+            {...props}
+            className="h-full cursor-pointer rounded-lg border border-transparent px-4 py-2 text-base font-medium bg-gray-900 text-white 
+                transition duration-200 hover:border-gray-400"
+        >
+            {children}
+        </button>
     )
 }
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,9 +1,23 @@
-import React from "react";
-
+/**
+ * Props for the Button component.
+ * Extends the default HTML button attributes.
+ *
+ * @typedef {Object} ButtonProps
+ * @property {React.ReactNode} children - The content inside the button (text, icons, or components).
+ * @extends {React.ButtonHTMLAttributes<HTMLButtonElement>}
+ */
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     children: React.ReactNode; // Accepts text, icons, or components inside the button
 }
 
+/**
+ * A reusable button component with Tailwind styling.
+ * Accepts all native `<button>` attributes (onClick, disabled, type, etc.).
+ *
+ * @param {React.ReactNode} children - The content inside the button.
+ * @param {ButtonProps} props - The props for the button component.
+ *
+ */
 const Button= ({children, ...props}: ButtonProps) => {
 
     return (

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    children: React.ReactNode; // Accepts text, icons, or components inside the button
+}
+
+const Button= ({children, ...props}: ButtonProps) => {
+
+    return (
+        <button {...props}>{children}</button>
+    )
+}
+
+export default Button;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,8 +23,8 @@ const Button= ({children, ...props}: ButtonProps) => {
     return (
         <button 
             {...props}
-            className="h-full cursor-pointer rounded-lg border border-transparent px-4 py-2 text-base font-medium bg-gray-900 text-white 
-                transition duration-200 hover:border-gray-400"
+            className={`cursor-pointer rounded-lg border border-transparent px-4 py-2 text-base 
+                font-medium bg-gray-900 text-white transition duration-200 hover:border-gray-400 ${props.className}`}
         >
             {children}
         </button>

--- a/src/components/CheckboxButton.tsx
+++ b/src/components/CheckboxButton.tsx
@@ -1,16 +1,17 @@
 
-interface CheckboxButtonProps {
+interface CheckboxButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>  {
     children: React.ReactNode; // Accepts text, icons, or components inside the button
     isChecked: boolean
-    onToggle: () => void;
 }
 
-const CheckboxButton = ({children, isChecked, onToggle} : CheckboxButtonProps) => {
+const CheckboxButton = ({children, isChecked, ...props} : CheckboxButtonProps) => {
 
   return (
     <button
-      onClick={onToggle}
-      className={`${isChecked ? "text-white border-2 border-white" : "text-gray-600"}`}
+        {...props}
+        className={`h-full cursor-pointer rounded-lg border border-transparent px-4 py-2 text-base font-medium 
+                transition duration-200 hover:bg-gray-800 ${isChecked ? "bg-gray-900 text-white" : "text-gray-500"}`}
+      
     >
       {children}
     </button>

--- a/src/components/CheckboxButton.tsx
+++ b/src/components/CheckboxButton.tsx
@@ -1,9 +1,26 @@
-
+/**
+ * Props for the CheckboxButton component.
+ * Extends the default HTML button attributes.
+ *
+ * @typedef {Object} CheckboxButtonProps
+ * @property {React.ReactNode} children - The content inside the button (text, icons, or components).
+ * @property {boolean} isChecked - Whether the checkbox button is active.
+ * @extends {React.ButtonHTMLAttributes<HTMLButtonElement>}
+ */
 interface CheckboxButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>  {
     children: React.ReactNode; // Accepts text, icons, or components inside the button
     isChecked: boolean
 }
 
+/**
+ * A button component that behaves like a checkbox.
+ * Accepts all native `<button>` attributes (onClick, disabled, type, etc.).
+ *
+ * @param {CheckboxButtonProps} props - The props for the checkbox button component.
+ * @param {React.ReactNode} children - The content inside the button.
+ * @param {boolean} isChecked - Whether the checkbox button is active.
+ *
+ */
 const CheckboxButton = ({children, isChecked, ...props} : CheckboxButtonProps) => {
 
   return (

--- a/src/components/CheckboxButton.tsx
+++ b/src/components/CheckboxButton.tsx
@@ -27,7 +27,8 @@ const CheckboxButton = ({children, isChecked, ...props} : CheckboxButtonProps) =
     <button
         {...props}
         className={`h-full cursor-pointer rounded-lg border border-transparent px-4 py-2 text-base font-medium 
-                transition duration-200 hover:bg-gray-800 ${isChecked ? "bg-gray-900 text-white" : "text-gray-500"}`}
+                transition duration-200 hover:bg-gray-800 ${isChecked ? "bg-gray-900 text-white" : "text-gray-500"} 
+                ${props.className}`}
       
     >
       {children}

--- a/src/components/CheckboxButton.tsx
+++ b/src/components/CheckboxButton.tsx
@@ -1,0 +1,20 @@
+
+interface CheckboxButtonProps {
+    children: React.ReactNode; // Accepts text, icons, or components inside the button
+    isChecked: boolean
+    onToggle: () => void;
+}
+
+const CheckboxButton = ({children, isChecked, onToggle} : CheckboxButtonProps) => {
+
+  return (
+    <button
+      onClick={onToggle}
+      className={`${isChecked ? "text-white border-2 border-white" : "text-gray-600"}`}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default CheckboxButton;

--- a/src/components/FlashCard.tsx
+++ b/src/components/FlashCard.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { motion, MotionConfig } from "motion/react"
+import { motion} from "motion/react"
 import { TFlashcard } from '../types/types.ts'
 
 interface FlashCardProps
@@ -16,7 +15,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped}: FlashCardProps) {
     if(isFlipped) {
         return (
             <motion.button
-                className="w-full h-48 block p-6 bg-white border border-grey-200 rounded-lg shadow-sm hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700 flex items-center justify-center"
+                className="w-full h-48 block p-6 cursor-pointer bg-white border border-grey-200 rounded-lg shadow-sm hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700 flex items-center justify-center"
                 onClick={() => setIsFlipped(false)}
                 initial={{ rotateY: 180 }}
                 animate={{ rotateY: 0 }}
@@ -31,7 +30,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped}: FlashCardProps) {
     else{
         return (
             <motion.button
-                className="w-full h-48 block p-6 bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700 flex items-center justify-center"
+                className="w-full h-48 block p-6 cursor-pointer bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700 flex items-center justify-center"
                 onClick={() => setIsFlipped(true)}
                 initial={{ rotateY: 0 }}
                 animate={{ rotateY: 180 }}

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { TFlashcard, TFlashcardSet } from "../types/types";
 import FlashCard from "./FlashCard.tsx";
 import Button from "./Button.tsx";
@@ -23,13 +23,21 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
     // State to track the current flashcard index
     const [currentIndex, setCurrentIndex] = useState<number>(0);
     //set isFlipped state to true so that the card is facing front side up
-    const [isFlipped, setIsFlipped] = useState(true);
+    const [isFlipped, setIsFlipped] = useState<boolean>(true);
 
     // Set isRandomized state to false so the cards retain the order they are loaded in
-    const [isRandomized, setIsRandomized] = useState(false);
+    const [isRandomized, setIsRandomized] = useState<boolean>(false);
 
     // Store the current flashcardSet in an array
-    const [currentSet, setCurrentSet] = useState(flashcardSet.flashcards);
+    const [currentSet, setCurrentSet] = useState<TFlashcard[]>(flashcardSet.flashcards);
+
+    useEffect(() => {
+        // Reset currentIndex, flipped state, and randomize when flashcardSet changes
+        setCurrentIndex(0);
+        setIsFlipped(true);
+        setIsRandomized(false);
+        setCurrentSet(flashcardSet.flashcards);
+    }, [flashcardSet])
 
     /**
      * Moves to the next flashcard in the set.
@@ -99,7 +107,7 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
         <div className="flex flex-col items-center mt-4 w-md max-w-md">
             {/* Displays flashcard set category and description */}
             <h1 className="text-2xl font-bold">{flashcardSet.category}</h1>
-            <p className="my-8">{flashcardSet.description}</p>
+            <p className="h-12 my-8">{flashcardSet.description}</p>
             {/* FlashCard Component */}
             <FlashCard cardData={currentFlashcard} isFlipped={isFlipped} setIsFlipped={setIsFlipped} />
             

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -23,10 +23,10 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
     // State to track the current flashcard index
     const [currentIndex, setCurrentIndex] = useState(0);
 
-    //set isFlipped state to true so that the card is facing front side up
+    // Set isFlipped state to true so that the card is facing front side up
     const [isFlipped, setIsFlipped] = useState(true);
 
-    //set isFlipped state to true so that the card is facing front side up
+    // Set isRandomized state to false so the cards retain the order they are loaded in
     const [isRandomized, setIsRandomized] = useState(false);
 
     // Store the current flashcardSet in an array
@@ -52,7 +52,8 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
 
     /**
      * 
-     * Function to shuffle the flashcard set using the Fisher-Yates algorithm
+     * Function to shuffle the flashcard set using the Fisher-Yates algorithm 
+     * (https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
      */
     const randomizeSet = () => {
         // Create a copy of the original flashcards array
@@ -96,7 +97,7 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
          * - Uses flexbox for centering.
          * - Currently relies on inline styles, which will be replaced by TailwindCSS.
          */
-        <div className="flex flex-col items-center mt-10 w-md max-w-md">
+        <div className="flex flex-col items-center mt-4 w-md max-w-md">
             {/* Displays flashcard set category and description */}
             <h1 className="text-2xl font-bold">{flashcardSet.category}</h1>
             <p className="my-8">{flashcardSet.description}</p>

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -107,13 +107,13 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
             {/* Navigation buttons for switching flashcards */}
             <div className="w-full flex flex-row gap-10 items-center h-12 mt-10">
                 <CheckboxButton 
-                    className="flex-1 h-full"
+                    className="h-full"
                     isChecked={isRandomized} 
                     onClick={handleToggleRandomize}>
                     <FaShuffle color={isRandomized ? "white" : "gray"} size={20}/>
                 </CheckboxButton>
                 <Button 
-                    className="flex-1"
+                    className="h-full"
                     onClick={handlePrev}>
                     <FaArrowLeftLong size={20} />
                 </Button>
@@ -123,7 +123,7 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
                     {currentIndex + 1}/{flashcardSet.flashcards.length}
                 </p>  
                 <Button 
-                    className="flex-1"
+                    className="h-full"
                     onClick={handleNext}>
                     <FaArrowRightLong size={20} />
                 </Button>

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -104,15 +104,15 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
          * - Uses flexbox for centering.
          * - Currently relies on inline styles, which will be replaced by TailwindCSS.
          */
-        <div className="flex flex-col items-center mt-4 w-md max-w-md">
+        <div className="flex flex-col items-center mt-2 w-md max-w-md">
             {/* Displays flashcard set category and description */}
-            <h1 className="text-2xl font-bold">{flashcardSet.category}</h1>
-            <p className="h-12 my-8">{flashcardSet.description}</p>
+            <h2>{flashcardSet.category}</h2>
+            <p className="h-12 my-4">{flashcardSet.description}</p>
             {/* FlashCard Component */}
             <FlashCard cardData={currentFlashcard} isFlipped={isFlipped} setIsFlipped={setIsFlipped} />
             
             {/* Navigation buttons for switching flashcards */}
-            <div className="w-full flex flex-row gap-10 items-center h-12 mt-10">
+            <div className="w-full flex flex-row gap-10 items-center h-12 mt-4">
                 <CheckboxButton 
                     className="h-full"
                     isChecked={isRandomized} 

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -2,6 +2,11 @@ import { useState } from "react";
 import { TFlashcard, TFlashcardSet } from "../types/types";
 import FlashCard from "./FlashCard.tsx";
 
+interface FlashCardContainerProps
+{
+    flashcardSet: TFlashcardSet
+}
+
 /**
  * FlashcardContainer Component
  * 
@@ -11,7 +16,7 @@ import FlashCard from "./FlashCard.tsx";
  * Props:
  * @param {TFlashcardSet} flashcardSet - The selected set of flashcards to display.
  */
-const FlashcardContainer = ({ flashcardSet }: { flashcardSet: TFlashcardSet }) => {
+const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
     // State to track the current flashcard index
     const [currentIndex, setCurrentIndex] = useState(0);
     //set isFlipped state to true so that the card is facing front side up

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -3,6 +3,7 @@ import { TFlashcard, TFlashcardSet } from "../types/types";
 import FlashCard from "./FlashCard.tsx";
 import Button from "./Button.tsx";
 import CheckboxButton from "./CheckboxButton.tsx";
+import { FaShuffle, FaArrowLeftLong, FaArrowRightLong } from "react-icons/fa6";
 
 interface FlashCardContainerProps
 {
@@ -97,17 +98,34 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
          */
         <div className="flex flex-col items-center mt-10 w-md max-w-md">
             {/* Displays flashcard set category and description */}
-            <h1>{flashcardSet.category}</h1>
+            <h1 className="text-2xl font-bold">{flashcardSet.category}</h1>
             <p className="my-8">{flashcardSet.description}</p>
             {/* FlashCard Component */}
             <FlashCard cardData={currentFlashcard} isFlipped={isFlipped} setIsFlipped={setIsFlipped} />
             
             {/* Navigation buttons for switching flashcards */}
-            <div className="flex gap-10 items-center mt-10">
-                <CheckboxButton isChecked={isRandomized} onToggle={handleToggleRandomize}>Random</CheckboxButton>
-                <Button onClick={handlePrev}>← Prev</Button>
-                <p>{currentIndex + 1}/{flashcardSet.flashcards.length}</p>  
-                <Button onClick={handleNext}>Next →</Button>
+            <div className="w-full flex flex-row gap-10 items-center h-12 mt-10">
+                <CheckboxButton 
+                    className="flex-1 h-full"
+                    isChecked={isRandomized} 
+                    onClick={handleToggleRandomize}>
+                    <FaShuffle color={isRandomized ? "white" : "gray"} size={20}/>
+                </CheckboxButton>
+                <Button 
+                    className="flex-1"
+                    onClick={handlePrev}>
+                    <FaArrowLeftLong size={20} />
+                </Button>
+                <p 
+                    className="flex-1 font-semibold text-lg"
+                >
+                    {currentIndex + 1}/{flashcardSet.flashcards.length}
+                </p>  
+                <Button 
+                    className="flex-1"
+                    onClick={handleNext}>
+                    <FaArrowRightLong size={20} />
+                </Button>
             </div>
         </div>
     );

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { TFlashcard, TFlashcardSet } from "../types/types";
 import FlashCard from "./FlashCard.tsx";
+import Button from "./Button.tsx";
+import CheckboxButton from "./CheckboxButton.tsx";
 
 interface FlashCardContainerProps
 {
@@ -19,8 +21,15 @@ interface FlashCardContainerProps
 const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
     // State to track the current flashcard index
     const [currentIndex, setCurrentIndex] = useState(0);
+
     //set isFlipped state to true so that the card is facing front side up
     const [isFlipped, setIsFlipped] = useState(true);
+
+    //set isFlipped state to true so that the card is facing front side up
+    const [isRandomized, setIsRandomized] = useState(false);
+
+    // Store the current flashcardSet in an array
+    const [currentSet, setCurrentSet] = useState(flashcardSet.flashcards);
 
     /**
      * Moves to the next flashcard in the set.
@@ -40,8 +49,44 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
         setIsFlipped(true);
     };
 
+    /**
+     * 
+     * Function to shuffle the flashcard set using the Fisher-Yates algorithm
+     */
+    const randomizeSet = () => {
+        // Create a copy of the original flashcards array
+        const shuffledSet = [...flashcardSet.flashcards]; 
+
+        for (let i = shuffledSet.length - 1; i > 0; i--) { 
+            const j = Math.floor(Math.random() * (i + 1)); // Generate a random index within the remaining unshuffled portion
+            [shuffledSet[i], shuffledSet[j]] = [shuffledSet[j], shuffledSet[i]]; // Swap the current element with the randomly chosen element
+        }
+
+        return shuffledSet;
+    };
+
+    /** 
+     * Function to toggle between randomized and original order of flashcards
+     */ 
+    const handleToggleRandomize = () => {
+        if (isRandomized) {
+            // Reset to the original flashcard order if currently randomized
+            setCurrentSet(flashcardSet.flashcards); 
+        } else {
+            // Shuffle and update the flashcard set if not randomized
+            setCurrentSet(randomizeSet()); 
+        }
+
+        // Toggle the isRandomized state
+        setIsRandomized((prevState) => !prevState); 
+
+        // Reset the flashcard index to the first card and ensure card is flipped
+        setCurrentIndex(0); 
+        setIsFlipped(true);
+    };
+
     // Store the current flashcard in a variable for better readability
-    const currentFlashcard : TFlashcard = flashcardSet.flashcards[currentIndex];
+    const currentFlashcard : TFlashcard = currentSet[currentIndex];
 
     return (
         /**
@@ -50,7 +95,7 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
          * - Uses flexbox for centering.
          * - Currently relies on inline styles, which will be replaced by TailwindCSS.
          */
-        <div className="flex flex-col items-center mt-10">
+        <div className="flex flex-col items-center mt-10 w-md max-w-md">
             {/* Displays flashcard set category and description */}
             <h1>{flashcardSet.category}</h1>
             <p className="my-8">{flashcardSet.description}</p>
@@ -59,9 +104,10 @@ const FlashcardContainer = ({ flashcardSet }: FlashCardContainerProps) => {
             
             {/* Navigation buttons for switching flashcards */}
             <div className="flex gap-10 items-center mt-10">
-                <button onClick={handlePrev}>← Prev</button>
+                <CheckboxButton isChecked={isRandomized} onToggle={handleToggleRandomize}>Random</CheckboxButton>
+                <Button onClick={handlePrev}>← Prev</Button>
                 <p>{currentIndex + 1}/{flashcardSet.flashcards.length}</p>  
-                <button onClick={handleNext}>Next →</button>
+                <Button onClick={handleNext}>Next →</Button>
             </div>
         </div>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
 }
-
+/* 
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
@@ -65,4 +65,4 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
-}
+} */

--- a/src/index.css
+++ b/src/index.css
@@ -29,12 +29,17 @@ body {
   min-width: 320px;
   min-height: 100vh;
 }
-/* 
+
 h1 {
-  font-size: 3.2em;
+  font-size: 3em;
   line-height: 1.1;
 }
 
+h2 {
+  font-size: 2.2em;
+}
+
+/* 
 button {
   border-radius: 8px;
   border: 1px solid transparent;

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -13,7 +13,7 @@ import { TFlashcardSet } from "../types/types";
 const FlashcardsPage = () => {
     // State to track which flashcard set is currently selected
     // Default set index is 0 (first set in the array)
-    const [selectedFlashcardSetIndex] = useState(2);
+    const [selectedFlashcardSetIndex] = useState(0);
 
     // Store the current flashcardSet in a variable for better readability
     const currentFlashcardSet : TFlashcardSet = flashcardData[selectedFlashcardSetIndex];

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -33,7 +33,6 @@ const FlashcardsPage = () => {
             <div style={{
                 display: "flex",
                 justifyContent: "center",
-                height: "100vh",
                 textAlign: "center"
             }}>
                 {/* Renders the selected flashcard set inside the FlashcardContainer */}

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -13,7 +13,7 @@ import { TFlashcardSet } from "../types/types";
 const FlashcardsPage = () => {
     // State to track which flashcard set is currently selected
     // Default set index is 0 (first set in the array)
-    const [selectedFlashcardSetIndex] = useState(0);
+    const [selectedFlashcardSetIndex] = useState(2);
 
     // Store the current flashcardSet in a variable for better readability
     const currentFlashcardSet : TFlashcardSet = flashcardData[selectedFlashcardSetIndex];

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -23,7 +23,6 @@ const FlashcardsPage = () => {
         <div style={{ 
             display: "flex", 
             justifyContent: "center", 
-            alignItems: "center", 
             height: "100vh",
             textAlign: "center" 
         }}>


### PR DESCRIPTION
### Changes
- Added react-icons to project. 
- Added a Button component and changed the left and right arrows in the flashcard-container to these Button components.  The Button components can take in a child component, text, etc and add it inside of the Button. A className with tailwind css can still be added to the Button component which will be added to the inner <button> as seen in the following image:

### Button Component
![image](https://github.com/user-attachments/assets/5173b7ac-d910-4eb0-a579-b70f7ba10805)

- Added a CheckboxButton component that has an isChecked state and an onClick function where you can set the isChecked boolean if needed. Similar to the Button component, it can pass a className prop in order to add tailwind css.

### CheckboxButton Component
![image](https://github.com/user-attachments/assets/258c1f5f-b9db-4bf2-9202-b21e9e922b36)

- A Randomize button has been added to the flashcard container as a CheckboxButton component. When the flahscards load, the isRandomized state is set to false which puts the cards in the order they are passed in as a prop. When the randomize button is clicked, it will call a randomize function that shuffles the cards and sets them as the currentFlashcards variable and the currentIndex is set back to 0. When the randomize button is toggled back off, the currentFlashcards is set back to the order they are originally passed in as a prop and once again the currentIndex is set back to 0. 

### Randomize Button/Function in Action
![RandomizeButtonNew](https://github.com/user-attachments/assets/b72b777c-2bd3-48ef-8eee-bfdbaa0449af)


**Note**: This PR commented out most of the index.css file which was styling all `<button>` components the same way. This PR now styles the Button and CheckboxButton with tailwind css, so buttons need tailwind styles (including cursor-pointer). We could also leave this in the index.css for properties that all buttons should have no matter what.

