### PR TITLE
Add in GitHub Actions Workflow for Automated Accessibiilty Testing with Pa11y

### DIFF
--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -48,7 +48,7 @@ jobs:
           npx pa11y http://localhost:4173 --config=pa11y-config.json || true
       - name: Check for accessibility violations and fail the workflow if found
         run: |
-          if echo "${{ steps.pa11y.outputs.stdout }}" | grep -q "Error"; then
+          if echo "${{ steps.pa11y.outputs.pa11y_output }}" | grep -q "Error:"; then
             echo "Accessibility violations found!"
             exit 1
           else

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -45,7 +45,9 @@ jobs:
           sleep 10
       - name: Run pa11y
         run: |
-          npx pa11y http://localhost:4173 --config=pa11y-config.json || true
+          output=$(npx pa11y http://localhost:4173 --config=pa11y-config.json || true)
+          echo "$output"
+          echo "::set-output name=pa11y_output::$output"
       - name: Check for accessibility violations and fail the workflow if found
         run: |
           if echo "${{ steps.pa11y.outputs.stdout }}" | grep -q "Accessibility violations found"; then

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -41,7 +41,7 @@ jobs:
           xdg-utils
       - name: Start VITE server
         run: |
-          nohup npm run preview --port 4173 &
+          nohup npm run preview &
           sleep 10
       - name: Run pa11y
         run: |

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Run pa11y
         run: |
           output=$(npx pa11y http://localhost:4173 --config=pa11y-config.json || true)
-          echo "PA11Y_OUTPUT=$output" >> $GITHUB_ENV
+          echo "$output" > pa11y_output.txt
       - name: Check for accessibility violations and fail the workflow if found
         run: |
-          if echo "${{ env.PA11Y_OUTPUT }}" | grep -q "Error:"; then
+          if grep -q "Error:" pa11y_output.txt; then
             echo "Accessibility violations found!"
             exit 1
           else

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -45,5 +45,5 @@ jobs:
           sleep 10
       - name: Run pa11y
         run: |
-          npx pa11y http://localhost:3000 --chrome-flags="--no-sandbox --disable-dev-shm-usage"
+          npx pa11y http://localhost:3000 --config=pa11y-config.json
         continue-on-error: true

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -15,11 +15,11 @@ jobs:
         run: npm ci
       - run: npm run build --if-present
       - name: Install Chrome
-        run:
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/sources.list.d/google.list'
+        run: |
           sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
+          sudo apt-get install -y wget
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt-get install -y ./google-chrome-stable_current_amd64.deb
       - name: Install Pa11y
         run: |
           npm install -g pa11y

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -14,15 +14,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - run: npm run build --if-present
-      - name: Install Chrome
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget
-          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo apt-get install -y ./google-chrome-stable_current_amd64.deb
-      - name: Install Pa11y
-        run: |
-          npm install -g pa11y
+      - name: Install Pa11y and Puppeteer
+        run: npm install -g pa11y puppeteer
       - run: npm run dev & npx wait-on http://localhost:3000 &
       - name: Run pa11y
-        run: pa11y http://localhost:3000 --chrome-launcher --no-sandbox
+        run: pa11y http://localhost:3000 --chromium-args="--no-sandbox"

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -41,9 +41,9 @@ jobs:
           xdg-utils
       - name: Start VITE server
         run: |
-          nohup npm run preview --port 3000 &
+          nohup npm run preview --port 4173 &
           sleep 10
       - name: Run pa11y
         run: |
-          npx pa11y http://localhost:3000 --config=pa11y-config.json
+          npx pa11y http://localhost:4173 --config=pa11y-config.json
         continue-on-error: true

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -45,12 +45,10 @@ jobs:
           sleep 10
       - name: Run pa11y
         run: |
-          output=$(npx pa11y http://localhost:4173 --config=pa11y-config.json || true)
-          echo "$output"
-          echo "::set-output name=pa11y_output::$output"
+          npx pa11y http://localhost:4173 --config=pa11y-config.json || true
       - name: Check for accessibility violations and fail the workflow if found
         run: |
-          if echo "${{ steps.pa11y.outputs.stdout }}" | grep -q "Accessibility violations found"; then
+          if echo "${{ steps.pa11y.outputs.stdout }}" | grep -q "Error"; then
             echo "Accessibility violations found!"
             exit 1
           else

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           output=$(npx pa11y http://localhost:4173 --config=pa11y-config.json || true)
           echo "$output" > pa11y_output.txt
+          cat pa11y_output.txt
       - name: Check for accessibility violations and fail the workflow if found
         run: |
           if grep -q "Error:" pa11y_output.txt; then

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -45,10 +45,11 @@ jobs:
           sleep 10
       - name: Run pa11y
         run: |
-          npx pa11y http://localhost:4173 --config=pa11y-config.json || true
+          output=$(npx pa11y http://localhost:4173 --config=pa11y-config.json || true)
+          echo "PA11Y_OUTPUT=$output" >> $GITHUB_ENV
       - name: Check for accessibility violations and fail the workflow if found
         run: |
-          if echo "${{ steps.pa11y.outputs.pa11y_output }}" | grep -q "Error:"; then
+          if echo "${{ env.PA11Y_OUTPUT }}" | grep -q "Error:"; then
             echo "Accessibility violations found!"
             exit 1
           else

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -18,6 +18,28 @@ jobs:
         run: npm run build
       - name: Install Pa11y
         run: npm install -g pa11y
+      - name: Install Chromium dependencies (for headless env)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+          wget \
+          curl \
+          ca-certificates \
+          fonts-liberation \
+          libappindicator3-1 \
+          libasound2 \
+          libatk-bridge2.0-0 \
+          libatk1.0-0 \
+          libcups2 \
+          libdbus-1-3 \
+          libgdk-pixbuf2.0-0 \
+          libnspr4 \
+          libnss3 \
+          libx11-xcb1 \
+          libxcomposite1 \
+          libxdamage1 \
+          libxrandr2 \
+          xdg-utils
       - name: Start VITE server
         run: |
           nohup npm run preview --port 3000 &

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install Pa11y, http-server, and Chromium for Pa11y
         run: |
           npm install -g pa11y http-server
-      - run: http-server ./dist --port 3000 &
+      # - run: http-server ./dist --port 3000 &
+      - run: npm run dev & npx wait-on http://localhost:3000 &
       - name: Run pa11y
         run: pa11y http://localhost:3000 || exit 0

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -27,7 +27,6 @@ jobs:
           ca-certificates \
           fonts-liberation \
           libappindicator3-1 \
-          libasound2 \
           libatk-bridge2.0-0 \
           libatk1.0-0 \
           libcups2 \

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -53,4 +53,4 @@ jobs:
             exit 1
           else
             echo "No accessibility violations found!"
-            exit 0
+          fi

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -14,10 +14,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - run: npm run build --if-present
-      - name: Install Pa11y, http-server, and Chromium for Pa11y
+      - name: Install Chrome
+        run:
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/sources.list.d/google.list'
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+      - name: Install Pa11y
         run: |
-          npm install -g pa11y http-server
-      # - run: http-server ./dist --port 3000 &
+          npm install -g pa11y
       - run: npm run dev & npx wait-on http://localhost:3000 &
       - name: Run pa11y
-        run: pa11y http://localhost:3000 || exit 0
+        run: pa11y http://localhost:3000 --chrome-launcher --no-sandbox

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -45,5 +45,5 @@ jobs:
           sleep 10
       - name: Run pa11y
         run: |
-          npx pa11y http://localhost:3000
+          npx pa11y http://localhost:3000 --chrome-flags="--no-sandbox --disable-dev-shm-usage"
         continue-on-error: true

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -6,16 +6,23 @@ jobs:
   pa11y:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Install dependencies
-        run: npm ci
-      - run: npm run build --if-present
-      - name: Install Pa11y and Puppeteer
-        run: npm install -g pa11y puppeteer
-      - run: npm run dev & npx wait-on http://localhost:3000 &
+        run: npm install
+      - name: Build the app
+        run: npm run build
+      - name: Install Pa11y
+        run: npm install -g pa11y
+      - name: Start VITE server
+        run: |
+          nohup npm run preview --port 3000 &
+          sleep 10
       - name: Run pa11y
-        run: pa11y http://localhost:3000 --chromium-args="--no-sandbox"
+        run: |
+          npx pa11y http://localhost:3000
+        continue-on-error: true

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -45,5 +45,12 @@ jobs:
           sleep 10
       - name: Run pa11y
         run: |
-          npx pa11y http://localhost:4173 --config=pa11y-config.json
-        continue-on-error: true
+          npx pa11y http://localhost:4173 --config=pa11y-config.json || true
+      - name: Check for accessibility violations and fail the workflow if found
+        run: |
+          if echo "${{ steps.pa11y.outputs.stdout }}" | grep -q "Accessibility violations found"; then
+            echo "Accessibility violations found!"
+            exit 1
+          else
+            echo "No accessibility violations found!"
+            exit 0

--- a/.github/workflows/pa11y-accessibility.yml
+++ b/.github/workflows/pa11y-accessibility.yml
@@ -1,0 +1,22 @@
+name: pa11y-accessibility-check
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  pa11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Install dependencies
+        run: npm ci
+      - run: npm run build --if-present
+      - name: Install Pa11y, http-server, and Chromium for Pa11y
+        run: |
+          npm install -g pa11y http-server
+      - run: http-server ./dist --port 3000 &
+      - name: Run pa11y
+        run: pa11y http://localhost:3000 || exit 0

--- a/pa11y-config.json
+++ b/pa11y-config.json
@@ -1,0 +1,5 @@
+{
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+    }
+  }  


### PR DESCRIPTION
## Description
This PR also adds in a GitHub workflow to run the pa11y library on open PRs to automatically test for accessibility (the job will fail if there are errors).

## Resources
- Adding a workflow to check for accessibility - https://bolonio.medium.com/automating-the-accessibility-tests-of-your-source-code-with-github-actions-63590cdc6860
- GitHub Workflow Node.js guide - https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml
- Workflow Linter - https://rhysd.github.io/actionlint/
- Pa11y config - https://stackoverflow.com/questions/78583618/pa11y-ci-with-nextjs-wont-pass-in-github-actions-ci

## Demo's/Images
1. Example of the workflow finding accessibility errors (when it was hitting the Chrome error page).
![image](https://github.com/user-attachments/assets/462aa654-df76-4c7a-a527-02fa9915a75b)

2. Our project passing with no accessibility errors. 🥲 
![image](https://github.com/user-attachments/assets/b007363b-211f-4c02-852c-664f5ac6ae73)
