### PR TITLE
Matt/password reset

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -91,7 +91,6 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
     // Map Firebase error codes to friendly custom messages
     const getAuthErrorMessage = (error: unknown): string => {
         if (error instanceof FirebaseError) {
-            console.log(error.code)
             switch (error.code) {
                 case "auth/invalid-email":
                     return "The email address is not valid.";
@@ -114,26 +113,36 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
 
     if (showPassReset){
         return (
-            <div className="p-4 max-w-md mx-auto">
+            <div className="bg-white dark:bg-gray-800 rounded-xl p-8 max-w-md mt-20 mx-4 md:mx-auto">
                 <h1 className="text-2xl font-bold mb-4 text-black dark:text-white">Reset Password</h1>
-                <form onSubmit={(e) => void handleRequestPasswordReset(e)} className="space-y-4">
-                    <div>
-                        <label className="text-sm font-medium text-black dark:text-white">Email</label>
+                <form onSubmit={(e) => void handleRequestPasswordReset(e)} className="space-y-6">
+                    {/* Email Field with "Back to Login" link */}
+                    <div className="flex flex-col">
+                        <label className="text-sm font-medium text-black dark:text-white ml-1 mr-auto">
+                                Email
+                            </label>
                         <input
                             type="email"
-                            className="mt-1 w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
+                            className="mt-1 w-full px-3 py-2 border border-2 border-gray-400 text-black dark:text-white rounded"
                             value={email}
                             onChange={(e) => setEmail(e.target.value)}
                         />
                     </div>
-                    {error && <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">{error}</p>}
 
+                    {/* Error Message */}
+                    {error && (
+                        <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">
+                            {error}
+                        </p>
+                    )}
+
+                    {/* Submit Button */}
                     <Button
                         aria-label="Send Reset Code Button"
                         title="Send Reset Code"
-                        className="h-full w-full !bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
+                        className="w-full !bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
                         type="submit"
-                    >
+                        >
                         Send Reset Code
                     </Button>
                     
@@ -141,7 +150,7 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
                 <Button
                         aria-label="Back to Login Button"
                         title="Back to Log In"
-                        className="h-full w-full mt-4 !bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700"
+                        className="w-full mt-4 !bg-red-400 dark:!bg-red-500 hover:!bg-red-500 dark:hover:!bg-red-600"
                         onClick={() => handleForgotPassword(false)}
                     >
                         Back to Login
@@ -151,29 +160,52 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
     }
 
     return (
-        <div className="p-4 max-w-md mx-auto">
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-8 max-w-md mt-20 mx-4 md:mx-auto">
             <h1 className="text-2xl font-bold mb-4 text-black dark:text-white">Admin Login</h1>
-            <form onSubmit={(e) => void handleLogin(e)} className="space-y-4">
-                <div>
-                    <label className="text-sm font-medium text-black dark:text-white">Email</label>
+            <form onSubmit={(e) => void handleLogin(e)} className="space-y-6">
+                {/* Email Field */}
+                <div className="flex flex-col">
+                    <label className="text-sm font-medium text-black dark:text-white ml-1 mr-auto">
+                        Email
+                    </label>
                     <input
                         type="email"
-                        className="mt-1 w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
+                        className="mt-1 w-full px-3 py-2 border border-2 border-gray-400 text-black dark:text-white rounded"
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                     />
                 </div>
-                <div>
-                    <label className="block text-sm font-medium text-black dark:text-white">Password</label>
+
+                {/* Password Field with Forgot Password Link */}
+                <div className="flex flex-col">
+                    <div className="flex justify-between items-center">
+                        <label className="text-sm font-medium text-black dark:text-white ml-1">
+                            Password
+                        </label>
+                        <button
+                            type="button"
+                            onClick={() => handleForgotPassword(true)}
+                            className="cursor-pointer text-sm text-blue-600 dark:text-blue-400 hover:underline focus:outline-none"
+                        >
+                            Forgot Password?
+                        </button>
+                    </div>
                     <input
                         type="password"
-                        className="mt-1 block w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
+                        className="mt-1 block w-full px-3 py-2 border border-2 border-gray-400 text-black dark:text-white rounded"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                     />
                 </div>
-                {error && <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">{error}</p>}
 
+                {/* Error Message */}
+                {error && (
+                    <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">
+                        {error}
+                    </p>
+                )}
+
+                {/* Submit Button */}
                 <Button
                     aria-label="Log In Button"
                     title="Log In"
@@ -182,16 +214,7 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
                 >
                     Log In
                 </Button>
-                
             </form>
-            <Button
-                    aria-label="Forgot Password Button"
-                    title="Forgot Password"
-                    className="h-full w-full mt-4 !bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700"
-                    onClick={() => handleForgotPassword(true)}
-                >
-                    Forgot Password
-            </Button>
         </div>
     );
 }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,70 +1,197 @@
 import { useState } from "react";
-import { signInWithEmailAndPassword } from "firebase/auth";
+import { signInWithEmailAndPassword, sendPasswordResetEmail } from "firebase/auth";
+import { FirebaseError } from "firebase/app";
 import { auth } from "../firebase";
 import { useAuth } from "../context/auth/useAuthContext";
 import Button from "./Button";
 
+/**
+ * LoginForm Component
+ * 
+ * This component handles admin authentication for the application.
+ * It allows the user to either:
+ * - Log in with email and password
+ * - Request a password reset email if they forgot their password
+ * 
+ * Features:
+ * - Email/password login with Firebase Authentication
+ * - Forgot Password flow using Firebase `sendPasswordResetEmail`
+ * - Form validation and error handling with friendly user messages
+ * - Accessible buttons with aria-labels and titles
+ * - Dark mode and light mode support for input fields and messages
+ * 
+ * Props:
+ * - onSuccess?: () => void
+ *    - An optional callback triggered after successful login
+ * 
+ * State:
+ * - email: string — the email entered by the user
+ * - password: string — the password entered by the user
+ * - error: string — current error message to display, if any
+ * - showPassReset: boolean — toggle to switch between login and password reset forms
+ * 
+ * Firebase Integration:
+ * - signInWithEmailAndPassword(auth, email, password)
+ * - sendPasswordResetEmail(auth, email)
+ * 
+ * Error Handling:
+ * - Friendly, mapped error messages based on Firebase error codes
+ * - Validation ensures user does not see raw Firebase error strings
+ * 
+ * Notes:
+ * - If the user is already logged in (currentUser exists), this component renders nothing.
+ * - After a successful password reset request, an alert confirms that an email was sent (regardless of whether the email exists).
+ * - No direct Firebase errors are shown to the user; they are mapped into custom, non-technical messages.
+ */
+
 type LoginFormProps = {
-  onSuccess?: () => void;
+    onSuccess?: () => void;
 };
 
 export default function LoginForm({ onSuccess }: LoginFormProps) {
     const { currentUser } = useAuth();
+    const [showPassReset, setShowPassReset] = useState(false);
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [error, setError] = useState("");
 
+    // Handle user login attempt with Firebase Auth
     const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault();
         setError("");
 
         try {
-        await signInWithEmailAndPassword(auth, email, password);
-        if (onSuccess) onSuccess();
+            await signInWithEmailAndPassword(auth, email, password);
+            if (onSuccess) onSuccess();
         } catch (err) {
-            if (err instanceof Error) {
-                setError(err.message);
-            } else {
-                setError("Login failed");
+            setError(getAuthErrorMessage(err));
+        }
+    };
+
+    // Toggle the forgot password form
+    const handleForgotPassword = (showReset: boolean) => {
+        setError("");
+        setPassword("");
+        setShowPassReset(showReset);
+    }
+
+    // Handle sending password reset email via Firebase
+    const handleRequestPasswordReset = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError("");
+
+        try {
+            await sendPasswordResetEmail(auth, email);
+            alert("If an account exists with this email, a password reset email has been sent.");
+        } catch (err) {
+            setError(getAuthErrorMessage(err));
+        }
+    };
+
+    // Map Firebase error codes to friendly custom messages
+    const getAuthErrorMessage = (error: unknown): string => {
+        if (error instanceof FirebaseError) {
+            console.log(error.code)
+            switch (error.code) {
+                case "auth/invalid-email":
+                    return "The email address is not valid.";
+                case "auth/user-not-found":
+                    return "No user found with this email.";
+                case "auth/invalid-credential":
+                    return "Incorrect email or password.";
+                case "auth/missing-password":
+                    return "Please enter a password.";
+                case "auth/too-many-requests":
+                    return "Too many attempts. Please try again later.";
+                default:
+                    return "An unknown error occurred. Please try again.";
             }
         }
+        return "An unexpected error occurred. Please try again.";
     };
 
     if (currentUser) return null;
 
+    if (showPassReset){
+        return (
+            <div className="p-4 max-w-md mx-auto">
+                <h1 className="text-2xl font-bold mb-4 text-black dark:text-white">Reset Password</h1>
+                <form onSubmit={(e) => void handleRequestPasswordReset(e)} className="space-y-4">
+                    <div>
+                        <label className="text-sm font-medium text-black dark:text-white">Email</label>
+                        <input
+                            type="email"
+                            className="mt-1 w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                        />
+                    </div>
+                    {error && <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">{error}</p>}
+
+                    <Button
+                        aria-label="Send Reset Code Button"
+                        title="Send Reset Code"
+                        className="h-full w-full !bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
+                        type="submit"
+                    >
+                        Send Reset Code
+                    </Button>
+                    
+                </form>
+                <Button
+                        aria-label="Back to Login Button"
+                        title="Back to Log In"
+                        className="h-full w-full mt-4 !bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700"
+                        onClick={() => handleForgotPassword(false)}
+                    >
+                        Back to Login
+                </Button>
+            </div>
+        )
+    }
+
     return (
         <div className="p-4 max-w-md mx-auto">
-        <h1 className="text-2xl font-bold mb-4 text-black dark:text-white">Admin Login</h1>
-        <form onSubmit={(e) => void handleLogin(e)} className="space-y-4">
-            <div>
-                <label className="text-sm font-medium text-black dark:text-white">Email</label>
-                <input
-                    type="email"
-                    className="mt-1 w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                />
-            </div>
-            <div>
-                <label className="block text-sm font-medium text-black dark:text-white">Password</label>
-                <input
-                    type="password"
-                    className="mt-1 block w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                />
-            </div>
-            {error && <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">{error}</p>}
+            <h1 className="text-2xl font-bold mb-4 text-black dark:text-white">Admin Login</h1>
+            <form onSubmit={(e) => void handleLogin(e)} className="space-y-4">
+                <div>
+                    <label className="text-sm font-medium text-black dark:text-white">Email</label>
+                    <input
+                        type="email"
+                        className="mt-1 w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-black dark:text-white">Password</label>
+                    <input
+                        type="password"
+                        className="mt-1 block w-full px-3 py-2 border border-gray-300 text-black dark:text-white rounded"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                    />
+                </div>
+                {error && <p className="font-bold p-1 bg-red-500 text-sm text-black dark:text-white rounded">{error}</p>}
 
+                <Button
+                    aria-label="Log In Button"
+                    title="Log In"
+                    className="h-full w-full !bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
+                    type="submit"
+                >
+                    Log In
+                </Button>
+                
+            </form>
             <Button
-                aria-label="Log In"
-                title="Log In"
-                className="h-full w-full !bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
-                type="submit"
-            >
-                Log In
+                    aria-label="Forgot Password Button"
+                    title="Forgot Password"
+                    className="h-full w-full mt-4 !bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700"
+                    onClick={() => handleForgotPassword(true)}
+                >
+                    Forgot Password
             </Button>
-        </form>
         </div>
     );
 }


### PR DESCRIPTION
### Description
This adds a way for the admins to change their password in the event they forgot it or just want a new password. A "Forgot Password?" link has been added to the password label on the LoginForm. When this is clicked, the LoginForm is replaced by a reset password form. The user can enter their email and if the email exists in firebase, a reset email link is sent to the user. The user can click the link that is sent to their email and it allows them to enter a new password. This is handled by firebase automatically and an it works really well since it will not email someone if the email doesn't exist in the firebase authorized users.

I have also added better error handling for login errors. Instead of showing the firebase auth errors directly, the errors are mapped to generic error strings that are shown in order to obfuscate the fact that firebase is handling the auth. Some examples of these messages are shown in the images below.


### Demo's/Images
Forgot Password link on the LoginForm
![image](https://github.com/user-attachments/assets/17f6955b-bcb5-4ea3-9950-60fef35d5582)

Reset Password component
![image](https://github.com/user-attachments/assets/019eed65-6ff2-476b-87ff-7a150050af5f)

Alert for reset email
![image](https://github.com/user-attachments/assets/794aa59a-84c9-43af-b900-c80799a09693)


New Error message handling
![image](https://github.com/user-attachments/assets/872bd857-edf9-4b96-81ac-af6e32f8451e)


The following images show some of the new error messages working.
![image](https://github.com/user-attachments/assets/b38a63b4-f3b1-4f7b-ac20-45fd7c50b19a)
![image](https://github.com/user-attachments/assets/44b8543a-634c-49c7-b49d-5929a6d26cf8)
![image](https://github.com/user-attachments/assets/023553a2-9754-4ef4-a917-8867f6c09544)

