### PR TITLE
Fix for Random Button

### DIFF
--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -3,7 +3,6 @@ import { TFlashcard } from "../types/types";
 import { Category, Flashcard } from "../context/flashcards/flashcardsContext.ts";
 import FlashCard from "./FlashCard.tsx";
 import Button from "./Button.tsx";
-import CheckboxButton from "./CheckboxButton.tsx";
 import { FaShuffle, FaArrowLeftLong, FaArrowRightLong, FaCircleQuestion } from "react-icons/fa6";
 import HintModal from "./HintModal";
 
@@ -31,8 +30,6 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
     const [showTooltip, setShowTooltip] = useState<boolean>(false);
     // set isFlipped state to true so that the card is facing front side up
     const [isFlipped, setIsFlipped] = useState<boolean>(true);
-    // Set isRandomized state to false so the cards retain the order they are loaded in
-    const [isRandomized, setIsRandomized] = useState<boolean>(false);
     // Store the current flashcardSet in an array
     const [currentSet, setCurrentSet] = useState<Flashcard[]>(flashcards);
 
@@ -44,8 +41,7 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
         // Reset currentIndex, flipped state, and randomize when flashcardSet changes
         setCurrentIndex(0);
         setIsFlipped(true);
-        setIsRandomized(false);
-        setCurrentSet(flashcards);
+        setCurrentSet(randomizeSet()); 
     }, [flashcards])
 
     // Wait 1 second after mount, then show tooltip
@@ -97,17 +93,9 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
     /** 
      * Function to toggle between randomized and original order of flashcards
      */ 
-    const handleToggleRandomize = () => {
-        if (isRandomized) {
-            // Reset to the original flashcard order if currently randomized
-            setCurrentSet(flashcards); 
-        } else {
-            // Shuffle and update the flashcard set if not randomized
-            setCurrentSet(randomizeSet()); 
-        }
-
-        // Toggle the isRandomized state
-        setIsRandomized((prevState) => !prevState); 
+    const handleRandomize = () => {
+        // Shuffle and update the flashcard set if not randomized
+        setCurrentSet(randomizeSet()); 
 
         // Reset the flashcard index to the first card and ensure card is flipped
         setCurrentIndex(0); 
@@ -164,14 +152,13 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
             
             {/* Navigation buttons for switching flashcards */}
             <div className="w-full flex flex-wrap items-center justify-center gap-2 sm:gap-5 mt-4 px-2">
-                <CheckboxButton 
+                <Button 
                     aria-label="Shuffle Button"
-                     title={`Click to ${isRandomized ? "unshuffle" : "shuffle"}`}
+                     title="Click to shuffle"
                      className="border border-gray-300 rounded-md px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base flex items-center gap-1"
-                     isChecked={isRandomized} 
-                     onClick={handleToggleRandomize}>
+                     onClick={handleRandomize}>
                      Shuffle <FaShuffle size={16} aria-hidden={true} />
-                </CheckboxButton>
+                </Button>
                 
                 <Button 
                     aria-label="Previous Flashcard Button"

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -35,10 +35,8 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
     const [hintLetter, setHintLetter] = useState("");
 
     useEffect(() => {
-        // Reset currentIndex, flipped state, and randomize when flashcardSet changes
-        setCurrentIndex(0);
-        setIsFlipped(true);
-        setCurrentSet(randomizeSet()); 
+        handleRandomize();
+        resetFlashcards();
     }, [flashcards])
 
     // Wait 1 second after mount, then show tooltip
@@ -72,7 +70,7 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
 
     /**
      * 
-     * Function to shuffle the flashcard set using the Fisher-Yates algorithm 
+     * Shuffle the flashcard set using the Fisher-Yates algorithm 
      * (https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
      */
     const randomizeSet = () => {
@@ -88,13 +86,16 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
     };
 
     /** 
-     * Function to toggle between randomized and original order of flashcards
+     * Randomize the flashcard order
      */ 
     const handleRandomize = () => {
-        // Shuffle and update the flashcard set if not randomized
         setCurrentSet(randomizeSet()); 
+    };
 
-        // Reset the flashcard index to the first card and ensure card is flipped
+    /** 
+     * Reset flashcards to first card and ensure card is flipped
+     */ 
+    const resetFlashcards = () => {
         setCurrentIndex(0); 
         setIsFlipped(true);
     };
@@ -154,9 +155,12 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
                     <div className="w-full flex flex-wrap items-center justify-center gap-2 sm:gap-5 mt-4 px-2">
                         <Button 
                             aria-label="Shuffle Button"
-                            title="Click to shuffle"
+                            title="Click to shuffle flashcards"
                             className="border border-gray-300 rounded-md px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base flex items-center gap-1"
-                            onClick={handleRandomize}>
+                            onClick={() => {
+                                handleRandomize();
+                                resetFlashcards();
+                            }}>
                             Shuffle <FaShuffle size={16} aria-hidden={true} />
                         </Button>
                         

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -136,63 +136,73 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
             className="flex flex-col items-center mt-2 sm:w-2xl sm:max-w-2xl"
         >
             {/* Displays flashcard set category and description */}
-            <h2 className="text-balance text-center  my-4 text-2xl sm:text-4xl font-bold
-                 text-black dark:text-white pl-[35px] pr-4 sm:pr-0 mr-2 sm:mr-0">
+            <h2 className="text-balance text-center my-4 mx-1 text-2xl sm:text-4xl font-bold
+                 text-black dark:text-white px-4">
                 {category.description}</h2>
+
             {/* FlashCard Component */}
-            <FlashCard 
-                cardData={currentFlashcard} 
-                showTooltip={showTooltip}
-                setShowTooltip={setShowTooltip}
-                isFlipped={isFlipped} 
-                setIsFlipped={setIsFlipped} 
-                isInitialLoad={isInitialLoad}
-                setIsInitialLoad={setIsInitialLoad}
-            />
-            
-            {/* Navigation buttons for switching flashcards */}
-            <div className="w-full flex flex-wrap items-center justify-center gap-2 sm:gap-5 mt-4 px-2">
-                <Button 
-                    aria-label="Shuffle Button"
-                     title="Click to shuffle"
-                     className="border border-gray-300 rounded-md px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base flex items-center gap-1"
-                     onClick={handleRandomize}>
-                     Shuffle <FaShuffle size={16} aria-hidden={true} />
-                </Button>
-                
-                <Button 
-                    aria-label="Previous Flashcard Button"
-                    title="Click to see previous flashcard"
-                    onClick={handlePrev}
-                    className="px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base text-green-800 font-bold hover:text-green-900 flex items-center gap-1"
-                    >
-                    Back <FaArrowLeftLong size={16} aria-hidden={true} />
-                </Button>
-                <p 
-                    className="flex-1 font-semibold text-lg text-black dark:text-white"
-                >
-                    {currentIndex + 1}/{flashcards.length}
-                </p>  
-                <Button
-                    aria-label="Next Flashcard Button"
-                    title="Click to see next flashcard"
-                    onClick={handleNext}
-                    className="px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base text-green-800 font-bold hover:text-green-900 flex items-center gap-1"
-                    >
-                     Next <FaArrowRightLong size={16} aria-hidden={true} />
-                </Button>
-                <Button
-                    aria-label="Help Button"
-                    title="Click to see a hint"
-                    onClick={handleHelpClick}
-                    className="px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base border border-blue-400 text-blue-600 dark:text-blue-300 rounded-md flex items-center gap-1"
-                    >
-                    Hint <FaCircleQuestion size={16} aria-hidden={true} />
-                </Button>
-                {showModal && (
-                <HintModal hintLetter={hintLetter} onClose={() => setShowModal(false)} />
-                )}
-            </div>
+            {
+                currentFlashcard ? 
+                <>
+                    <FlashCard 
+                        cardData={currentFlashcard} 
+                        showTooltip={showTooltip}
+                        setShowTooltip={setShowTooltip}
+                        isFlipped={isFlipped} 
+                        setIsFlipped={setIsFlipped} 
+                        isInitialLoad={isInitialLoad}
+                        setIsInitialLoad={setIsInitialLoad}
+                    /> 
+                    {/* Navigation buttons for switching flashcards */}
+                    <div className="w-full flex flex-wrap items-center justify-center gap-2 sm:gap-5 mt-4 px-2">
+                        <Button 
+                            aria-label="Shuffle Button"
+                            title="Click to shuffle"
+                            className="border border-gray-300 rounded-md px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base flex items-center gap-1"
+                            onClick={handleRandomize}>
+                            Shuffle <FaShuffle size={16} aria-hidden={true} />
+                        </Button>
+                        
+                        <Button 
+                            aria-label="Previous Flashcard Button"
+                            title="Click to see previous flashcard"
+                            onClick={handlePrev}
+                            className="px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base text-green-800 font-bold hover:text-green-900 flex items-center gap-1"
+                            >
+                            Back <FaArrowLeftLong size={16} aria-hidden={true} />
+                        </Button>
+                        <p 
+                            className="flex-1 font-semibold text-lg text-black dark:text-white"
+                        >
+                            {currentIndex + 1}/{flashcards.length}
+                        </p>  
+                        <Button
+                            aria-label="Next Flashcard Button"
+                            title="Click to see next flashcard"
+                            onClick={handleNext}
+                            className="px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base text-green-800 font-bold hover:text-green-900 flex items-center gap-1"
+                            >
+                            Next <FaArrowRightLong size={16} aria-hidden={true} />
+                        </Button>
+                        <Button
+                            aria-label="Help Button"
+                            title="Click to see a hint"
+                            onClick={handleHelpClick}
+                            className="px-2 sm:px-4 py-1 sm:py-2 text-sm sm:text-base border border-blue-400 text-blue-600 dark:text-blue-300 rounded-md flex items-center gap-1"
+                            >
+                            Hint <FaCircleQuestion size={16} aria-hidden={true} />
+                        </Button>
+                        {showModal && (
+                        <HintModal hintLetter={hintLetter} onClose={() => setShowModal(false)} />
+                        )}
+                    </div>
+                </>
+            : 
+                <h3 className="p-20 text-3xl lg:text-7xl font-bold tracking-tight text-gray-900 dark:text-white 
+                text-center break-words px-2 backface-hidden">
+                    No flashcards exist in this category
+                </h3>
+            }
         </div>
     );
 };


### PR DESCRIPTION
### Description
The flashcards used to load in the order they were created in the flashcard-data.ts, but once they Firestore database started to be used, they were being loaded in alphabetical order. This PR makes it so flashcards are always loaded in random order. It also changes the Randomize Toggle Button into a regular Randomize Button since there is no longer a default order. When the Randomize Button is clicked, it will reorder the flashcards and start back at the first card in the category. No more toggling the random feature on and off.

This also adds one small feature where the FlashcardContainer checks if there is a valid currentFlashcard and only shows the Flashcard component if it exists. If not, meaning there are no flashcards in the selected category, it will show a message to the user that says "No flashcards exist in this category". Before this fix, if no flashcards existed in a category, then the entire page would be blank and would not let the user choose another category.

### Note
CheckboxButton.tsx is no longer used in the app and could probably be removed from the project, unless we want to keep it for potential future use.