### PR TITLE
Category Custom Order and Loading Spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="public/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GRC Accounting Flashcards</title>
   </head>

--- a/src/components/EditCategoryModal.tsx
+++ b/src/components/EditCategoryModal.tsx
@@ -29,7 +29,7 @@ export default function EditCategoryModal({ category, onClose }: EditCategoryMod
         if (isEditing) {
             editCategory({ id: category.id, updates: { name, description } });
           } else {
-            addCategory({ name, description });
+            addCategory({ name, description, order: category.order });
           }
 
         onClose();

--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -1,3 +1,5 @@
+import LoadingSpinner from "./LoadingSpinner";
+
 // LoadingModal.tsx
 type LoadingModalProps = {
     isOpen: boolean;
@@ -8,7 +10,7 @@ export default function LoadingModal({ isOpen }: LoadingModalProps) {
   
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black opacity-50">
-            <div className="animate-spin rounded-full h-16 w-16 border-4 border-t-transparent border-white"></div>
+            <LoadingSpinner />
         </div>
     );
 }

--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -1,0 +1,15 @@
+// LoadingModal.tsx
+type LoadingModalProps = {
+    isOpen: boolean;
+};
+  
+export default function LoadingModal({ isOpen }: LoadingModalProps) {
+    if (!isOpen) return null;
+  
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black opacity-50">
+            <div className="animate-spin rounded-full h-16 w-16 border-4 border-t-transparent border-white"></div>
+        </div>
+    );
+}
+  

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+
+const LoadingSpinner = () => {
+    return (
+        <div className="flex items-center justify-center">
+            <div className="animate-spin rounded-full h-16 w-16 border-4 border-t-transparent border-white"></div>
+        </div>
+    )
+}
+
+export default LoadingSpinner;

--- a/src/components/SeedButton.tsx
+++ b/src/components/SeedButton.tsx
@@ -29,13 +29,14 @@ export default function SeedButton() {
       
             console.log("Deleted old categories and flashcards");
       
-            for (const category of flashcardData) {
+            for (const [index, category] of flashcardData.entries()) {
                 const { category: name, description, flashcards } = category;
 
                 // 3. Add the category to the 'categories' collection
                 const categoryDoc = await addDoc(collection(db, "categories"), {
                     name,
                     description,
+                    order: index,
                 });
 
                 const categoryId = categoryDoc.id;

--- a/src/context/auth/AuthProvider.tsx
+++ b/src/context/auth/AuthProvider.tsx
@@ -24,11 +24,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       
         return () => unsubscribe();
     }, []);
-  
-    if (isAuthorizing) {
-      return <div>Signing In...</div>; 
-    }
-  
+    
     return (
         <AuthContext.Provider value={{ currentUser, isAuthorizing }}>
             {children}

--- a/src/context/flashcards/FlashcardsProvider.tsx
+++ b/src/context/flashcards/FlashcardsProvider.tsx
@@ -241,6 +241,33 @@ export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
         );
     };
 
+    const categoryStatuses = [
+        addCategoryMutation.status,
+        editCategoryMutation.status,
+        deleteCategoryMutation.status,
+        reorderCategoriesMutation.status,
+    ];
+    
+    let categoryStatus: 'pending' | 'error' | 'idle' = 'idle';
+    if (categoryStatuses.some(status => status === 'pending')) {
+        categoryStatus = 'pending';
+    } else if (categoryStatuses.some(status => status === 'error')) {
+        categoryStatus = 'error';
+    }
+
+    const flashcardStatuses = [
+        addFlashcardMutation.status,
+        editFlashcardMutation.status,
+        deleteFlashcardMutation.status,
+    ];
+
+    let flashcardStatus: 'pending' | 'error' | 'idle' = 'idle';
+    if (flashcardStatuses.some(status => status === 'pending')) {
+        flashcardStatus = 'pending';
+    } else if (flashcardStatuses.some(status => status === 'error')) {
+        flashcardStatus = 'error';
+    }
+
     return (
         <FlashcardsContext.Provider value={{
             categories,
@@ -252,10 +279,12 @@ export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
             addCategory: addCategoryMutation.mutate,
             editCategory: editCategoryMutation.mutate,
             deleteCategory: deleteCategoryMutation.mutate,
+            categoryStatus: categoryStatus,
             reorderCategories: reorderCategoriesMutation.mutate,
             addFlashcard: addFlashcardMutation.mutate,
             editFlashcard: editFlashcardMutation.mutate,            
-            deleteFlashcard: deleteFlashcardMutation.mutate,           
+            deleteFlashcard: deleteFlashcardMutation.mutate,    
+            flashcardStatus: flashcardStatus,       
         }}>
             {children}
         </FlashcardsContext.Provider>

--- a/src/context/flashcards/FlashcardsProvider.tsx
+++ b/src/context/flashcards/FlashcardsProvider.tsx
@@ -136,7 +136,14 @@ export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
     const deleteCategoryMutation = useMutation({
         mutationFn: async (id: string) => {
             const categoryRef = doc(db, "categories", id);
+            const flashcardsRef = doc(db, "flashcards", id);
+            
+            // Delete the category document
             await deleteDoc(categoryRef);
+
+            // Delete the corresponding flashcards document
+            await deleteDoc(flashcardsRef);
+
             await updateLastModified();
         },
         onSuccess: () => {

--- a/src/context/flashcards/FlashcardsProvider.tsx
+++ b/src/context/flashcards/FlashcardsProvider.tsx
@@ -286,12 +286,12 @@ export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
             addCategory: addCategoryMutation.mutate,
             editCategory: editCategoryMutation.mutate,
             deleteCategory: deleteCategoryMutation.mutate,
-            categoryStatus: categoryStatus,
+            categoryStatus,
             reorderCategories: reorderCategoriesMutation.mutate,
             addFlashcard: addFlashcardMutation.mutate,
             editFlashcard: editFlashcardMutation.mutate,            
             deleteFlashcard: deleteFlashcardMutation.mutate,    
-            flashcardStatus: flashcardStatus,       
+            flashcardStatus,       
         }}>
             {children}
         </FlashcardsContext.Provider>

--- a/src/context/flashcards/FlashcardsProvider.tsx
+++ b/src/context/flashcards/FlashcardsProvider.tsx
@@ -145,6 +145,28 @@ export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
         },
     });
 
+    const reorderCategoriesMutation = useMutation({
+        mutationFn: async ({ fromIndex, toIndex }: { fromIndex: number; toIndex: number }) => {
+            const categoryA = categories[fromIndex];
+            const categoryB = categories[toIndex];
+    
+            if (!categoryA || !categoryB) return;
+    
+            const refA = doc(db, "categories", categoryA.id);
+            const refB = doc(db, "categories", categoryB.id);
+    
+            await Promise.all([
+                updateDoc(refA, { order: categoryB.order }),
+                updateDoc(refB, { order: categoryA.order }),
+            ]);
+    
+            await updateLastModified();
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ["flashcards-and-categories"] });
+        },
+    });
+
     // ----- Flashcard Mutations -----
 
     const addFlashcardMutation = useMutation({
@@ -227,12 +249,13 @@ export const FlashcardsProvider = ({ children }: { children: ReactNode }) => {
             isDataError,
             dataError,
             getFlashcardsByCategory,
-            editCategory: editCategoryMutation.mutate,
-            editFlashcard: editFlashcardMutation.mutate,
-            deleteCategory: deleteCategoryMutation.mutate,
-            deleteFlashcard: deleteFlashcardMutation.mutate,
             addCategory: addCategoryMutation.mutate,
+            editCategory: editCategoryMutation.mutate,
+            deleteCategory: deleteCategoryMutation.mutate,
+            reorderCategories: reorderCategoriesMutation.mutate,
             addFlashcard: addFlashcardMutation.mutate,
+            editFlashcard: editFlashcardMutation.mutate,            
+            deleteFlashcard: deleteFlashcardMutation.mutate,           
         }}>
             {children}
         </FlashcardsContext.Provider>

--- a/src/context/flashcards/flashcardsContext.ts
+++ b/src/context/flashcards/flashcardsContext.ts
@@ -21,13 +21,14 @@ export type FlashcardsContextType = {
     getFlashcardsByCategory: (categoryId: string) => Flashcard[];
     isLoadingData: boolean;
     isDataError: boolean;
-    dataError: Error | null;
-    editCategory: (params: { id: string; updates: Partial<Category> }) => void;
-    editFlashcard: (flashcard: Flashcard) => void;
-    deleteCategory: (id: string) => void;
-    deleteFlashcard: (flashcard: Flashcard) => void;
+    dataError: Error | null;    
     addCategory: (category: Omit<Category, "id">) => void;
+    editCategory: (params: { id: string; updates: Partial<Category> }) => void;
+    deleteCategory: (id: string) => void;
+    reorderCategories: (params: { fromIndex: number; toIndex: number }) => void;
     addFlashcard: (flashcard: Omit<Flashcard, "id">) => void;
+    editFlashcard: (flashcard: Flashcard) => void;
+    deleteFlashcard: (flashcard: Flashcard) => void;
 };
   
 export const FlashcardsContext = createContext<FlashcardsContextType | undefined>(undefined);

--- a/src/context/flashcards/flashcardsContext.ts
+++ b/src/context/flashcards/flashcardsContext.ts
@@ -25,10 +25,12 @@ export type FlashcardsContextType = {
     addCategory: (category: Omit<Category, "id">) => void;
     editCategory: (params: { id: string; updates: Partial<Category> }) => void;
     deleteCategory: (id: string) => void;
+    categoryStatus: string;
     reorderCategories: (params: { fromIndex: number; toIndex: number }) => void;
     addFlashcard: (flashcard: Omit<Flashcard, "id">) => void;
     editFlashcard: (flashcard: Flashcard) => void;
     deleteFlashcard: (flashcard: Flashcard) => void;
+    flashcardStatus: string;
 };
   
 export const FlashcardsContext = createContext<FlashcardsContextType | undefined>(undefined);

--- a/src/context/flashcards/flashcardsContext.ts
+++ b/src/context/flashcards/flashcardsContext.ts
@@ -4,6 +4,7 @@ export type Category = {
     id: string;
     name: string;
     description: string;
+    order: number;
 };
   
 export type Flashcard = {

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -8,6 +8,7 @@ import { Category, Flashcard } from "../context/flashcards/flashcardsContext";
 import Button from "../components/Button";
 import {useEffect} from "react";
 import Dropdown from "../components/Dropdown";
+import {FaArrowUp, FaArrowDown} from "react-icons/fa";
 
 //How many flashcards to display at a time
 const ITEMS_PER_PAGE = 5;
@@ -15,7 +16,7 @@ const PAGE_WINDOW = 5;
 
 const AdminPage = () => {
     const { currentUser } = useAuth();
-    const { categories, flashcards, deleteCategory, deleteFlashcard } = useFlashcards();
+    const { categories, flashcards, deleteCategory, reorderCategories, deleteFlashcard } = useFlashcards();
 
     const [activeCategoryId, setActiveCategoryId] = useState("");
     const [ currentPage, setCurrentPage] = useState(1);
@@ -68,7 +69,12 @@ const AdminPage = () => {
         if (confirm(`Are you sure you want to delete the flashcard ${flashcard.front}?`)) {
             deleteFlashcard(flashcard);
         }
-      };
+    };
+
+    const handleReorder = (fromIndex: number, toIndex: number) => {
+      reorderCategories({ fromIndex, toIndex });
+    };
+
     //filter flashcards by active category
     const filteredFlashcards = flashcards.filter(card => card.categoryId === activeCategoryId);
 
@@ -119,21 +125,48 @@ const AdminPage = () => {
        
 
                 <ul className="space-y-3">
-                    {categories.map((category) => (
-                        <li
-                            key={category.id}
-                            className="flex items-center justify-between border border-gray-300 dark:border-gray-700 rounded p-4"
-                        >
-                            <div>
-                                <h3 className="text-start font-semibold">{category.name}</h3>
-                                <p className="text-start text-sm text-gray-600 dark:text-gray-400">{category.description}</p>
+                    {categories.map((category, index) => (
+                      <li
+                        key={category.id}
+                        className="flex items-center justify-between gap-4 border border-gray-300 dark:border-gray-700 rounded p-4"
+                      >
+                        {/* Title/Description */}
+                        <div className="flex-1">
+                            <h3 className="text-start font-semibold">{category.name}</h3>
+                            <p className="text-start text-sm text-gray-600 dark:text-gray-400">{category.description}</p>
+                        </div>
+                    
+                        {/* Action Buttons: Edit/Delete + Up/Down */}
+                        <div className="flex flex-col sm:flex-row gap-2 shrink-0">
+
+                          {/* Reorder Buttons */}
+                          <div className="flex flex-row gap-2 justify-end">
+                                <Button
+                                    aria-label={`Move ${category.name} Up`}
+                                    title="Move Up"
+                                    disabled={index === 0}
+                                    onClick={() => handleReorder(index, index - 1)}
+                                    className="!bg-blue-500 disabled:opacity-50 px-2"
+                                >
+                                    <FaArrowUp />
+                                </Button>
+                                <Button
+                                    aria-label={`Move ${category.name} Down`}
+                                    title="Move Down"
+                                    disabled={index === categories.length - 1}
+                                    onClick={() => handleReorder(index, index + 1)}
+                                    className="!bg-blue-500 disabled:opacity-50 px-2"
+                                >
+                                    <FaArrowDown />
+                                </Button>
                             </div>
 
+                            {/* Edit/Delete */}
                             <div className="flex gap-2 sm:flex-row flex-col">
                                 <Button
                                     aria-label={`Edit Category Button For ${category.name}`}
                                     title={`Edit Category For ${category.name}`}
-                                    className="!bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
+                                    className="!bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700 px-3"
                                     onClick={() => setEditingCategory(category)}
                                 >
                                     Edit
@@ -141,13 +174,14 @@ const AdminPage = () => {
                                 <Button
                                     aria-label={`Delete Category Button For ${category.name}`}
                                     title={`Delete Category For ${category.name}`}
-                                    className="!bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700"
+                                    className="!bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700 px-3"
                                     onClick={() => handleDeleteCategory(category)}
                                 >
                                     Delete
                                 </Button>
-                            </div>
-                        </li>
+                            </div>                     
+                        </div>
+                      </li>
                     ))}
                 </ul>
             </section>

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -9,6 +9,7 @@ import Button from "../components/Button";
 import {useEffect} from "react";
 import Dropdown from "../components/Dropdown";
 import {FaArrowUp, FaArrowDown} from "react-icons/fa";
+import LoadingModal from "../components/LoadingModal";
 
 //How many flashcards to display at a time
 const ITEMS_PER_PAGE = 5;
@@ -16,7 +17,7 @@ const PAGE_WINDOW = 5;
 
 const AdminPage = () => {
     const { currentUser } = useAuth();
-    const { categories, flashcards, deleteCategory, reorderCategories, deleteFlashcard } = useFlashcards();
+    const { categories, flashcards, deleteCategory, reorderCategories, deleteFlashcard, isLoadingData, categoryStatus, flashcardStatus } = useFlashcards();
 
     const [activeCategoryId, setActiveCategoryId] = useState("");
     const [ currentPage, setCurrentPage] = useState(1);
@@ -25,6 +26,7 @@ const AdminPage = () => {
     const [editingFlashcard, setEditingFlashcard] = useState<Flashcard | null>(null);
 
     const [selectedIndex, setSelectedIndex] = useState(0);
+    const [pending, setPending] = useState(false);
 
     //sync selectedindex when activecategoryid changes
     useEffect(() => {
@@ -44,6 +46,10 @@ const AdminPage = () => {
         }
       }
     }, [selectedIndex, categories]);
+
+    useEffect(() => {
+        setPending(categoryStatus === 'pending' || flashcardStatus === 'pending')
+    }, [categoryStatus, flashcardStatus])
 
     // SHow the login form if no admin is signed in
     if (!currentUser) return <LoginForm />;
@@ -72,7 +78,7 @@ const AdminPage = () => {
     };
 
     const handleReorder = (fromIndex: number, toIndex: number) => {
-      reorderCategories({ fromIndex, toIndex });
+        reorderCategories({ fromIndex, toIndex });
     };
 
     //filter flashcards by active category
@@ -107,6 +113,9 @@ const AdminPage = () => {
     }
     const pageNumbers = getPageNumbers();
 
+    if (isLoadingData){
+        return <>Loading...</>
+    }
 
     return (
         <div className="p-6 max-w-4xl mx-auto text-black dark:text-white">
@@ -306,6 +315,7 @@ const AdminPage = () => {
                 activeCategoryId={activeCategoryId}
                 onClose={() => setEditingFlashcard(null)}
             />
+            <LoadingModal isOpen={pending} />
         </div>
     );
 };

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -28,14 +28,6 @@ const AdminPage = () => {
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [pending, setPending] = useState(false);
 
-    //sync selectedindex when activecategoryid changes
-    useEffect(() => {
-      const index = categories.findIndex((c) => c.id === activeCategoryId);
-      if(index !== -1 && index !== selectedIndex){
-        setSelectedIndex(index);
-      }
-    }, [activeCategoryId, categories]);
-
     //sync active categoryid when selectedindex changes
     useEffect(() => {
       if(selectedIndex >= 0 && selectedIndex < categories.length){

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -111,7 +111,7 @@ const AdminPage = () => {
                 <Button
                     aria-label={`Add Category Button`}
                     title={`Add New Category`}
-                    onClick={() => setEditingCategory({ id: "", name: "", description: "" })}
+                    onClick={() => setEditingCategory({ id: "", name: "", description: "", order: categories.length })}
                     className="mb-4 px-4 py-2 !bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700"
                 >
                     + Add Category

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAuth } from "../context/auth/useAuthContext";
 import { useFlashcards } from "../context/flashcards/useFlashcards";
 import LoginForm from "../components/LoginForm";
@@ -6,9 +6,8 @@ import EditCategoryModal from "../components/EditCategoryModal";
 import EditFlashcardModal from "../components/EditFlashcardModal";
 import { Category, Flashcard } from "../context/flashcards/flashcardsContext";
 import Button from "../components/Button";
-import {useEffect} from "react";
 import Dropdown from "../components/Dropdown";
-import {FaArrowUp, FaArrowDown} from "react-icons/fa";
+import { FaAngleUp, FaAngleDown } from "react-icons/fa";
 import LoadingModal from "../components/LoadingModal";
 
 //How many flashcards to display at a time
@@ -131,57 +130,52 @@ const AdminPage = () => {
                         key={category.id}
                         className="flex items-center justify-between gap-4 border border-gray-300 dark:border-gray-700 rounded p-4"
                       >
+                        {/* Reorder Buttons */}
+                        <div className="flex flex-col gap-1 justify-end">
+                          <Button
+                              aria-label={`Move ${category.name} Up`}
+                              title={`Move ${category.name} Up`}
+                              disabled={index === 0}
+                              onClick={() => handleReorder(index, index - 1)}
+                              className="!bg-gray-300 dark:!bg-gray-700 disabled:opacity-30"
+                          >
+                              <FaAngleUp />
+                          </Button>
+                          <Button
+                              aria-label={`Move ${category.name} Down`}
+                              title={`Move ${category.name} Down`}
+                              disabled={index === categories.length - 1}
+                              onClick={() => handleReorder(index, index + 1)}
+                              className="!bg-gray-300 dark:!bg-gray-700 disabled:opacity-30"
+                          >
+                              <FaAngleDown />
+                          </Button>
+                        </div>
                         {/* Title/Description */}
                         <div className="flex-1">
-                            <h3 className="text-start font-semibold">{category.name}</h3>
-                            <p className="text-start text-sm text-gray-600 dark:text-gray-400">{category.description}</p>
+                            <h3 className="text-start text-lg font-semibold">{category.name}</h3>
+                            <p className="text-start text-gray-800 dark:text-gray-400">{category.description}</p>
                         </div>
                     
-                        {/* Action Buttons: Edit/Delete + Up/Down */}
-                        <div className="flex flex-col sm:flex-row gap-2 shrink-0">
-
-                          {/* Reorder Buttons */}
-                          <div className="flex flex-row gap-2 justify-end">
-                                <Button
-                                    aria-label={`Move ${category.name} Up`}
-                                    title="Move Up"
-                                    disabled={index === 0}
-                                    onClick={() => handleReorder(index, index - 1)}
-                                    className="!bg-blue-500 disabled:opacity-50 px-2"
-                                >
-                                    <FaArrowUp />
-                                </Button>
-                                <Button
-                                    aria-label={`Move ${category.name} Down`}
-                                    title="Move Down"
-                                    disabled={index === categories.length - 1}
-                                    onClick={() => handleReorder(index, index + 1)}
-                                    className="!bg-blue-500 disabled:opacity-50 px-2"
-                                >
-                                    <FaArrowDown />
-                                </Button>
-                            </div>
-
-                            {/* Edit/Delete */}
-                            <div className="flex gap-2 sm:flex-row flex-col">
-                                <Button
-                                    aria-label={`Edit Category Button For ${category.name}`}
-                                    title={`Edit Category For ${category.name}`}
-                                    className="!bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700 px-3"
-                                    onClick={() => setEditingCategory(category)}
-                                >
-                                    Edit
-                                </Button>
-                                <Button
-                                    aria-label={`Delete Category Button For ${category.name}`}
-                                    title={`Delete Category For ${category.name}`}
-                                    className="!bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700 px-3"
-                                    onClick={() => handleDeleteCategory(category)}
-                                >
-                                    Delete
-                                </Button>
-                            </div>                     
-                        </div>
+                        {/* Edit/Delete */}
+                        <div className="flex gap-2 sm:flex-row flex-col">
+                          <Button
+                              aria-label={`Edit Category Button For ${category.name}`}
+                              title={`Edit Category For ${category.name}`}
+                              className="!bg-green-500 dark:!bg-green-600 hover:!bg-green-600 dark:hover:!bg-green-700 px-3"
+                              onClick={() => setEditingCategory(category)}
+                          >
+                              Edit
+                          </Button>
+                          <Button
+                              aria-label={`Delete Category Button For ${category.name}`}
+                              title={`Delete Category For ${category.name}`}
+                              className="!bg-red-500 dark:!bg-red-600 hover:!bg-red-600 dark:hover:!bg-red-700 px-3"
+                              onClick={() => handleDeleteCategory(category)}
+                          >
+                              Delete
+                          </Button>
+                          </div>       
                       </li>
                     ))}
                 </ul>

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -54,7 +54,7 @@ const AdminPage = () => {
     // Only allow category deletion if it's not being used by a flashcard
     const handleDeleteCategory = (category: Category) => {
         if (isCategoryInUse(category.id)) {
-            alert("This category is currently in use and cannot be deleted.");
+            alert("This category contains flashcards and cannot be deleted.");
             return;
         }
 

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -9,13 +9,14 @@ import Button from "../components/Button";
 import Dropdown from "../components/Dropdown";
 import { FaAngleUp, FaAngleDown } from "react-icons/fa";
 import LoadingModal from "../components/LoadingModal";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 //How many flashcards to display at a time
 const ITEMS_PER_PAGE = 5;
 const PAGE_WINDOW = 5;
 
 const AdminPage = () => {
-    const { currentUser } = useAuth();
+    const { currentUser, isAuthorizing } = useAuth();
     const { categories, flashcards, deleteCategory, reorderCategories, deleteFlashcard, isLoadingData, categoryStatus, flashcardStatus } = useFlashcards();
 
     const [activeCategoryId, setActiveCategoryId] = useState("");
@@ -42,8 +43,18 @@ const AdminPage = () => {
         setPending(categoryStatus === 'pending' || flashcardStatus === 'pending')
     }, [categoryStatus, flashcardStatus])
 
-    // SHow the login form if no admin is signed in
+    // Show signing in text if user is being authorized
+    if (isAuthorizing) {
+      return <div className="fixed inset-0 flex items-center justify-center text-black dark:text-white">Signing In...</div>; 
+    }
+
+    // Show the login form if no admin is signed in
     if (!currentUser) return <LoginForm />;
+
+    // Show loading spinner while data is being loaded
+    if (isLoadingData){
+      return <div className="mt-20"><LoadingSpinner /></div>
+    }
 
     // Check if a category is being used in any flashcard
     const isCategoryInUse = (categoryId: string) => {
@@ -103,10 +114,6 @@ const AdminPage = () => {
       return pages;
     }
     const pageNumbers = getPageNumbers();
-
-    if (isLoadingData){
-        return <>Loading...</>
-    }
 
     return (
         <div className="p-6 max-w-4xl mx-auto text-black dark:text-white">

--- a/src/pages/FlashcardsPage.tsx
+++ b/src/pages/FlashcardsPage.tsx
@@ -3,8 +3,8 @@ import FlashcardContainer from "../components/FlashcardContainer";
 import Dropdown from "../components/Dropdown";
 import { useFlashcards } from "../context/flashcards/useFlashcards";
 import { Category, Flashcard } from "../context/flashcards/flashcardsContext";
-
 import Instructions from "../components/Instructions";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 /**
  * FlashcardsPage Component
@@ -36,7 +36,7 @@ const FlashcardsPage = () => {
     }, [selectedFlashcardSetIndex, categories, flashcards, isLoadingData, getFlashcardsByCategory]);
     
     if (isLoadingData || !currentFlashcardSet || !currentCategory){
-        return <div>Loading...</div>
+        return <div className="mt-20"><LoadingSpinner /></div>
     }
 
     return (


### PR DESCRIPTION
### Description
This adds functionality to categories so they can be sorted in a custom order instead of alphabetically. An index field has been added to each category in Firestore called "order". When the database is first seeded from the original firebase-data.ts, the order index is created based on the index of the categories in data file. When categories are pulled from Firestore, they are now ordered by the "order" field. When a new category is created, it is automatically added as the last category (using categories.length). Up and down arrow buttons have been added to the categories on the admin page which now allows admins to reorder the categories. A new function has been added to the flashcardsContext.ts which takes in two indices and swaps those indices in the Firestore. 

A LoadingSpinner component has also been added to the project. This spinner is shown whenever Firestore operations are done which helps the user know when an operation is occurring after making a change. A LoadingModal has also been added to the project which just contains the LoadingSpinner inside of a full screen modal. This modal is shown when the Category or Flashcards are created, edited, or deleted in the AdminPage, which stops the user from clicking on anything while the operation is completing. The LoadingSpinner is shown on the FlashcardsPage while the data is loading and on the AdminPage while the data is loading.

A small fix was also done here as well so that if a category is deleted, the flashcard document that was created using that categoryId is also deleted so that there aren't a bunch of empty flashcard documents when categories are deleted. 

### Images

Category Reorder buttons
![image](https://github.com/user-attachments/assets/26e8ba7d-4e20-4614-96c9-232185ef1d56)

Loading Spinner while data is loading
![image](https://github.com/user-attachments/assets/0ee8a72e-9900-47be-8826-0342fed31898)

Transparent LoadingModal during Firestore operations
![image](https://github.com/user-attachments/assets/34ca9461-0530-4f29-9003-3c4c918f0f59)

FlashcardsContext now exports a categoryStatus and a flashcardStatus. Either are strings that are 'idle', 'error', or 'pending'. 'pending' is used to show a loading spinner on pages when a category or flashcard is in the middle of a CRUD operation.
![image](https://github.com/user-attachments/assets/99fac01d-0d68-42d4-aeff-d70e9ad16df0)

AdminPage sets the pending status to true if either categoryStatus or flashcardStatus = 'pending'
![image](https://github.com/user-attachments/assets/63010a61-73c4-4d33-9a16-76a87e21d710)
![image](https://github.com/user-attachments/assets/83b998e6-4ed3-43f3-9903-b468173d8284)

LoadingModal is shown when the pending variable is true
![image](https://github.com/user-attachments/assets/cd502dbe-a3ae-4996-a0dc-4b759aa14d0f)



