### PR TITLE
Switch to HashRouter so routes work on GitHub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, HashRouter } from 'react-router-dom';
 import FlashcardsPage from './pages/FlashcardsPage';
 import AdminPage from './pages/AdminPage';
 import Header from './components/Header';
@@ -26,12 +26,14 @@ function App() {
             <AuthProvider>
                 <FlashcardsProvider>
                     <Header />
-                    <Routes>
-                        <Route path="/Accounting-Online-Flashcards" element={<FlashcardsPage />} />
-                        <Route path="/Accounting-Online-Flashcards/admin" element={<AdminPage />} />
-                    </Routes>
+                    <HashRouter>
+                        <Routes>
+                            <Route index element={<FlashcardsPage />} />
+                            <Route path="/admin" element={<AdminPage />} />
+                        </Routes>
+                    </HashRouter>
                 </FlashcardsProvider>
-            </AuthProvider>  
+            </AuthProvider>
         </QueryClientProvider>      
     );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from "react-router-dom";
 import './index.css';
 import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-        <App />
-    </BrowserRouter>
+      <App />
   </StrictMode>,
 )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,5 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: "Accounting-Online-Flashcards"
+  base: "/Accounting-Online-Flashcards"
 })


### PR DESCRIPTION
### Description
This PR makes a switch to HashRouter instead of BrowserRouter. BrowserRouter was not letting the admin route work on github after deploying since it wanted server side rendering. HashRouter allows the admin route to work correctly.

The new admin route is now at /#/admin. The # is how the HashRouter works.

 ### Images
![image](https://github.com/user-attachments/assets/230bba07-2140-450f-9b34-009967177ff7)
