### PR TITLE
G/hint button restructure

### DIFF
--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -115,7 +115,7 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
         const currentFlashcard = currentSet[currentIndex];
         const fullAnswer = String(currentFlashcard.back);
         const shorten = fullAnswer.substring(0, 1);
-        setHintLetter(shorten);
+        setHintLetter(shorten + "...");
         setShowModal(true);
         }
         setShowModal(true)

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -112,11 +112,9 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
             const creditHint = backData[1].charAt(0) ?? "";
             setHintLetter(`Debit: ${debitHint}...\nCredit: ${creditHint}...`);
         }else{
-        const currentFlashcard = currentSet[currentIndex];
-        const fullAnswer = String(currentFlashcard.back);
-        const shorten = fullAnswer.substring(0, 1);
+        const fullAnswer = backData[0];
+        const shorten = fullAnswer.charAt(0) ?? "";
         setHintLetter(shorten + "...");
-        setShowModal(true);
         }
         setShowModal(true)
     };

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -104,12 +104,6 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
     const currentFlashcard : Flashcard = currentSet[currentIndex];
 
     //function for the help button
-    //add logic for cardData.back.length > 1
-    /*
-        const leftHint = backData[0]?.charAt(0) ?? "";
-            const rightHint = backData[1]?.charAt(0) ?? "";
-            setHintLetter(`${leftHint} , ${rightHint}`);
-    */
     const handleHelpClick = () => {
         const backData = currentFlashcard.back 
         if (Array.isArray(backData) && backData.length > 1) {

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -105,13 +105,18 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
 
     //function for the help button
     //add logic for cardData.back.length > 1
+    /*
+        const leftHint = backData[0]?.charAt(0) ?? "";
+            const rightHint = backData[1]?.charAt(0) ?? "";
+            setHintLetter(`${leftHint} , ${rightHint}`);
+    */
     const handleHelpClick = () => {
         const backData = currentFlashcard.back 
         if (Array.isArray(backData) && backData.length > 1) {
             // Two parts to the answer (e.g., Debit / Credit)
-            const leftHint = backData[0]?.charAt(0) ?? "";
-            const rightHint = backData[1]?.charAt(0) ?? "";
-            setHintLetter(`${leftHint} , ${rightHint}`);
+            const debitHint = backData[0].charAt(0) ?? "";
+            const creditHint = backData[1].charAt(0) ?? "";
+            setHintLetter(`Debit: ${debitHint}...\nCredit: ${creditHint}...`);
         }else{
         const currentFlashcard = currentSet[currentIndex];
         const fullAnswer = String(currentFlashcard.back);

--- a/src/components/HintModal.tsx
+++ b/src/components/HintModal.tsx
@@ -4,7 +4,6 @@ interface HintModalProps {
   hintLetter: string;
   onClose: () => void;
 }
-//<p className="text-2xl text-blue-600 dark:text-blue-300">{hintLetter}</p>
 const HintModal: React.FC<HintModalProps> = ({ hintLetter, onClose }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/10 backdrop-blur-sm">

--- a/src/components/HintModal.tsx
+++ b/src/components/HintModal.tsx
@@ -4,13 +4,15 @@ interface HintModalProps {
   hintLetter: string;
   onClose: () => void;
 }
-
+//<p className="text-2xl text-blue-600 dark:text-blue-300">{hintLetter}</p>
 const HintModal: React.FC<HintModalProps> = ({ hintLetter, onClose }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/10 backdrop-blur-sm">
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg w-80 text-center">
         <h2 className="text-lg font-semibold mb-4 text-black dark:text-white">Hint</h2>
-        <p className="text-2xl text-blue-600 dark:text-blue-300">{hintLetter}</p>
+          <div className="text-2xl text-blue-600 dark:text-blue-300 whitespace-pre-line">
+              {hintLetter}
+          </div>
         <button
           onClick={onClose}
           className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -5,7 +5,7 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
-const testMode = false;
+const testMode = true;
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -5,7 +5,7 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
-const testMode = true;
+const testMode = false;
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional


### PR DESCRIPTION
This pull request if for the restructure of the hint button modal. From the usability testing students found it to be more helpful to have "Debit" and "Credit" fixed with the first letter of the correct account still showing.

HintModal.tsx:
![image](https://github.com/user-attachments/assets/57a52d25-611a-4d88-a7c5-a5da150f7c49)

Change to FlashcardContainer.tsx:
![image](https://github.com/user-attachments/assets/87354094-41c3-44a3-9433-7a7acd8f071a)
