### PR TITLE
Keyboard shortcuts and Collapsible Instructions

### DIFF
--- a/src/components/FlashCard.tsx
+++ b/src/components/FlashCard.tsx
@@ -25,7 +25,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped, showTooltip, setShowToolt
     if(isFlipped) {
         return (
             <motion.button
-                className="mx-6 h-[280px] md:w-[850px] md:h-[450px] flex p-6 cursor-pointer rounded-lg shadow-sm
+                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[805px] md:h-[450px] flex p-6 cursor-pointer rounded-lg shadow-sm
                         bg-white dark:bg-[#31A959]  dark:border-gray-700 dark:text-black
                         hover:bg-gray-100 dark:hover:bg-[#00A86B] items-center justify-center"
                 onClick={() => {
@@ -66,7 +66,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped, showTooltip, setShowToolt
     else if(cardData.back.length > 1){
         return (
             <motion.button
-                className="mx-6 h-[280px] md:w-[850px] md:h-[450px] flex p-6 cursor-pointer bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100
+                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[805px] md:h-[450px] flex p-6 cursor-pointer bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100
                             dark:bg-gray-800 dark:border-gray-700 neon-border dark:hover:bg-gray-700 items-center justify-center"
                 onClick={() => setIsFlipped(true)}
                 initial={{ rotateY: 0 }}
@@ -109,7 +109,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped, showTooltip, setShowToolt
     else{
         return (
             <motion.button
-                className="mx-6 h-[280px] md:w-[850px] md:h-[450px] flex p-6 cursor-pointer bg-[#eed9c4] border border-gray-200 rounded-lg shadow-sm hover:bg-[#f7e7ce] dark:bg-gray-800
+                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[805px] md:h-[450px] flex p-6 cursor-pointer bg-[#eed9c4] border border-gray-200 rounded-lg shadow-sm hover:bg-[#f7e7ce] dark:bg-gray-800
                             dark:border-gray-700 neon-border dark:hover:bg-gray-700 items-center justify-center"
                 onClick={() => setIsFlipped(true)}
                 initial={{ rotateY: 0 }}

--- a/src/components/FlashCard.tsx
+++ b/src/components/FlashCard.tsx
@@ -25,7 +25,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped, showTooltip, setShowToolt
     if(isFlipped) {
         return (
             <motion.button
-                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[805px] md:h-[450px] flex p-6 cursor-pointer rounded-lg shadow-sm
+                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[850px] md:h-[450px] flex p-6 cursor-pointer rounded-lg shadow-sm
                         bg-white dark:bg-[#31A959]  dark:border-gray-700 dark:text-black
                         hover:bg-gray-100 dark:hover:bg-[#00A86B] items-center justify-center"
                 onClick={() => {
@@ -66,7 +66,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped, showTooltip, setShowToolt
     else if(cardData.back.length > 1){
         return (
             <motion.button
-                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[805px] md:h-[450px] flex p-6 cursor-pointer bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100
+                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[850px] md:h-[450px] flex p-6 cursor-pointer bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100
                             dark:bg-gray-800 dark:border-gray-700 neon-border dark:hover:bg-gray-700 items-center justify-center"
                 onClick={() => setIsFlipped(true)}
                 initial={{ rotateY: 0 }}
@@ -109,7 +109,7 @@ function FlashCard({cardData, isFlipped, setIsFlipped, showTooltip, setShowToolt
     else{
         return (
             <motion.button
-                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[805px] md:h-[450px] flex p-6 cursor-pointer bg-[#eed9c4] border border-gray-200 rounded-lg shadow-sm hover:bg-[#f7e7ce] dark:bg-gray-800
+                className="mx-6 w-[90%] h-[280px] md:w-[750px] lg:w-[850px] md:h-[450px] flex p-6 cursor-pointer bg-[#eed9c4] border border-gray-200 rounded-lg shadow-sm hover:bg-[#f7e7ce] dark:bg-gray-800
                             dark:border-gray-700 neon-border dark:hover:bg-gray-700 items-center justify-center"
                 onClick={() => setIsFlipped(true)}
                 initial={{ rotateY: 0 }}

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -48,25 +48,6 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
         return () => clearTimeout(timer);
     }, []);
 
-    // Keydown listeners for arrow key/spacebar events
-    useEffect(() => {
-        const handleKeyPress = (e: KeyboardEvent) => {
-            if (e.key === 'ArrowLeft') {
-                handlePrev();
-            } else if (e.key === 'ArrowRight') {
-                handleNext()
-            } else if (e.key === ' ') {
-                setIsFlipped(prevState => !prevState);
-                setShowTooltip(false);
-            }
-	    };
-	    document.addEventListener('keydown', handleKeyPress);
-
-        return function () {
-            document.removeEventListener('keydown', handleKeyPress);
-        };
-    }, []);
-
     /**
      * Moves to the next flashcard in the set.
      * Loops back to the first card when reaching the end.
@@ -131,12 +112,56 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
             const creditHint = backData[1].charAt(0) ?? "";
             setHintLetter(`Debit: ${debitHint}...\nCredit: ${creditHint}...`);
         }else{
-        const fullAnswer = backData[0];
-        const shorten = fullAnswer.charAt(0) ?? "";
-        setHintLetter(shorten + "...");
+            const fullAnswer = backData[0];
+            const shorten = fullAnswer.charAt(0) ?? "";
+            setHintLetter(shorten + "...");
         }
         setShowModal(true)
     };
+
+    /**
+     * Keydown listeners for arrow key/spacebar events
+     * Left and Right arrow keys change to next or previous flashcards
+     * Spacebar flips the flashcard
+     * S key shuffles the flashcards
+     * H key shows/hides the hint modal
+     */
+    useEffect(() => {
+
+        const handleKeyPress = (e: KeyboardEvent) => {
+            switch (e.key){
+                case 'ArrowLeft':
+                    handlePrev();
+                    break;
+                case 'ArrowRight':
+                    handleNext()
+                    break;
+                case ' ':
+                    setIsFlipped(prevState => !prevState);
+                    setShowTooltip(false);
+                    break;
+                case 'S':
+                case 's':
+                    handleRandomize();
+                    resetFlashcards();
+                    break;
+                case 'H':
+                case 'h':
+                    if (showModal){
+                        setShowModal(false);
+                    }else{
+                        handleHelpClick();
+                    }                    
+                    break;
+            }
+	    };
+        
+	    document.addEventListener('keydown', handleKeyPress);
+
+        return function () {
+            document.removeEventListener('keydown', handleKeyPress);
+        };
+    }, [showModal, currentFlashcard]);
 
     return (
         /**

--- a/src/components/FlashcardContainer.tsx
+++ b/src/components/FlashcardContainer.tsx
@@ -46,7 +46,26 @@ const FlashcardContainer = ({ flashcards, category }: FlashCardContainerProps) =
         }, 1000);
     
         return () => clearTimeout(timer);
-      }, []);
+    }, []);
+
+    // Keydown listeners for arrow key/spacebar events
+    useEffect(() => {
+        const handleKeyPress = (e: KeyboardEvent) => {
+            if (e.key === 'ArrowLeft') {
+                handlePrev();
+            } else if (e.key === 'ArrowRight') {
+                handleNext()
+            } else if (e.key === ' ') {
+                setIsFlipped(prevState => !prevState);
+                setShowTooltip(false);
+            }
+	    };
+	    document.addEventListener('keydown', handleKeyPress);
+
+        return function () {
+            document.removeEventListener('keydown', handleKeyPress);
+        };
+    }, []);
 
     /**
      * Moves to the next flashcard in the set.

--- a/src/components/Instructions.tsx
+++ b/src/components/Instructions.tsx
@@ -1,21 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FaAngleUp, FaAngleDown } from "react-icons/fa";
 
-//border border-gray-200
 const Instructions: React.FC = () => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
   return (
     <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-md p-6 w-full sm:max-w-2xl mt-8 
                     border border-gray-200 dark:border-green-700 text-left md:ml-3">
-    <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
-      How to use the Flashcards
-    </h2>
-    <ul className="list-disc list-inside space-y-2 text-gray-700 dark:text-gray-300 text-sm">
-      <li>Select one of the 3 accounting topics for your flashcards</li>
-      <li>Click on the “Shuffle” button to shuffle your flashcards</li>
-      <li>Click on the flashcard to see the answer</li>
-      <li>Click the “Next Flashcard” button to move onto the next flashcard</li>
-      <li>Click the “Hint” button to see the first letter of the answer</li>
-    </ul>
-  </div>
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">
+          How to use the Flashcards
+        </h2>
+        <button
+          onClick={() => setIsCollapsed(prev => !prev)}
+          className="text-black dark:text-white hover:underline focus:outline-none cursor-pointer"
+          aria-label={isCollapsed ? 'Expand instructions' : 'Collapse instructions'}
+        >
+          <div className="flex gap-1 items-center">
+            <span>{isCollapsed ? "Show" : "Hide"}</span>
+            {isCollapsed ? <FaAngleDown size={20} /> : <FaAngleUp size={20} />}
+            
+          </div>
+        </button>
+      </div>
+
+      {!isCollapsed && (
+        <ul className="list-disc list-inside space-y-2 text-gray-700 dark:text-gray-300 text-sm mt-4">
+          <li>Select one of the 3 accounting topics for your flashcards</li>
+          <li>Click on the “Shuffle” button to shuffle your flashcards</li>
+          <li>Click on the flashcard to see the answer</li>
+          <li>Click the “Next Flashcard” button to move onto the next flashcard</li>
+          <li>Click the “Hint” button to see the first letter of the answer</li>
+          <li>Keyboard Shortcuts: ←/→ for Previous/Next, H for Hint, S to Shuffle</li>
+        </ul>
+      )}
+    </div>
   );
 };
 

--- a/src/components/Instructions.tsx
+++ b/src/components/Instructions.tsx
@@ -31,7 +31,7 @@ const Instructions: React.FC = () => {
           <li>Click on the flashcard to see the answer</li>
           <li>Click the “Next Flashcard” button to move onto the next flashcard</li>
           <li>Click the “Hint” button to see the first letter of the answer</li>
-          <li>Keyboard Shortcuts: ←/→ for Previous/Next, H for Hint, S to Shuffle</li>
+          <li>Keyboard Shortcuts: ←/→ for Previous/Next, Space to Flip, H for Hint, S to Shuffle</li>
         </ul>
       )}
     </div>


### PR DESCRIPTION
### Description
This allows the user to navigate the flashcard app with only the keyboard if they prefer. Keyboard shortcuts have been added for the following: Next/Previous flashcards, Hint, and Shuffle.  Left and Right right arrow keys will navigate to the next or previous flashcard, H will show/hide the hint modal, and S will shuffle the flashcards.

The instructions for the keyboard shortcuts have also been added to the Instructions component. A button has been added to the Instructions component that will expand or collapse the div so the user can choose to view instructions or hide them while using the app.

A small fix is included for the flashcard width. On mobile, the width of the flashcard component was shrinking to the size of the text, so a 90% default width was added, as well as a medium and large breakpoint size in order to work on mobile/tablet/desktop. Small screens will be 90% width, medium will be 750px width, and the rest will be 850px.


### Images

Key listener function for shortcuts
![image](https://github.com/user-attachments/assets/225cc1d4-a390-4a52-8810-5aa36cb8f002)

Expanded Instructions
![image](https://github.com/user-attachments/assets/16054272-b11f-4e38-b221-a1f983caa7bd)

Collapsed Instructions
![image](https://github.com/user-attachments/assets/123dd718-b102-4738-8f7a-c040a472f3aa)

Flashcard breakpoint change
![image](https://github.com/user-attachments/assets/e5d288dc-9786-4af6-a49a-713e772c71db)

